### PR TITLE
[codex] Make content extraction Reddit-aware

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,9 +15,25 @@ const turndownService = new TurndownService({
 });
 
 const SUPPORTED_FORMATS = new Set(['html', 'markdown', 'text']);
+export const TOOL_NAME = 'extract_web_content';
+const DEFAULT_MAX_CHARS = -1;
+const REDDIT_COMMENT_LIMIT = 20;
 
 function normalizeWhitespace(value) {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+function nullableString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 function renderTextFromHtml(html) {
@@ -39,22 +55,57 @@ export function renderArticleContent(article, format = 'markdown') {
 }
 
 export function truncateRenderedContent(content, maxChars) {
-  if (maxChars == null) {
+  const limit = maxChars ?? DEFAULT_MAX_CHARS;
+
+  if (!Number.isInteger(limit) || limit < -1) {
+    throw new Error('maxChars must be an integer greater than or equal to -1');
+  }
+
+  if (limit === DEFAULT_MAX_CHARS) {
     return { content, truncated: false };
   }
 
-  if (!Number.isInteger(maxChars) || maxChars < 0) {
-    throw new Error('maxChars must be a non-negative integer');
-  }
-
-  if (content.length <= maxChars) {
+  if (content.length <= limit) {
     return { content, truncated: false };
   }
 
   return {
-    content: content.slice(0, maxChars),
+    content: content.slice(0, limit),
     truncated: true
   };
+}
+
+function buildMetadata({
+  format,
+  excerpt = null,
+  byline = null,
+  siteName = null,
+  truncated,
+  permalink,
+  provider
+}) {
+  return {
+    format,
+    excerpt: nullableString(excerpt),
+    byline: nullableString(byline),
+    siteName: nullableString(siteName),
+    truncated,
+    permalink,
+    provider
+  };
+}
+
+export function isRedditUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return hostname === 'reddit.com'
+      || hostname === 'www.reddit.com'
+      || hostname === 'old.reddit.com'
+      || hostname === 'redd.it';
+  } catch {
+    return false;
+  }
 }
 
 export class WebsiteParser {
@@ -90,46 +141,284 @@ export class WebsiteParser {
     return {
       title: article.title,
       content,
-      format,
-      excerpt: article.excerpt,
-      byline: article.byline,
-      siteName: article.siteName,
-      truncated
+      metadata: buildMetadata({
+        format,
+        excerpt: article.excerpt,
+        byline: article.byline,
+        siteName: article.siteName,
+        truncated,
+        permalink: url,
+        provider: { type: 'web' }
+      })
     };
+  }
+}
+
+function normalizeRedditJsonUrl(url) {
+  const parsed = new URL(url);
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (hostname === 'redd.it') {
+    const postId = parsed.pathname.split('/').filter(Boolean)[0];
+    if (!postId) {
+      throw new Error('Reddit short URL must include a post id');
+    }
+
+    const jsonUrl = new URL(`https://www.reddit.com/comments/${postId}.json`);
+    jsonUrl.searchParams.set('raw_json', '1');
+    jsonUrl.searchParams.set('sort', 'top');
+    jsonUrl.searchParams.set('limit', String(REDDIT_COMMENT_LIMIT));
+    return jsonUrl.toString();
+  }
+
+  parsed.hostname = 'www.reddit.com';
+  parsed.protocol = 'https:';
+  parsed.hash = '';
+
+  if (!parsed.pathname.endsWith('.json')) {
+    parsed.pathname = `${parsed.pathname.replace(/\/$/, '')}.json`;
+  }
+
+  parsed.searchParams.set('raw_json', '1');
+  parsed.searchParams.set('sort', 'top');
+  parsed.searchParams.set('limit', String(REDDIT_COMMENT_LIMIT));
+  return parsed.toString();
+}
+
+function flattenTopLevelComments(children, limit = REDDIT_COMMENT_LIMIT) {
+  const comments = [];
+
+  for (const child of children ?? []) {
+    if (comments.length >= limit) {
+      break;
+    }
+
+    if (child?.kind !== 't1') {
+      continue;
+    }
+
+    const data = child.data ?? {};
+    comments.push({
+      author: nullableString(data.author) ? `u/${data.author}` : null,
+      body: nullableString(data.body) ?? '',
+      permalink: nullableString(data.permalink)
+        ? `https://www.reddit.com${data.permalink}`
+        : null
+    });
+  }
+
+  return comments;
+}
+
+function parseRedditResponse(payload) {
+  if (!Array.isArray(payload) || payload.length < 2) {
+    throw new Error('Unexpected Reddit JSON response');
+  }
+
+  const post = payload[0]?.data?.children?.[0]?.data;
+  if (!post) {
+    throw new Error('Reddit post was not found');
+  }
+
+  const comments = flattenTopLevelComments(payload[1]?.data?.children);
+  const permalink = nullableString(post.permalink)
+    ? `https://www.reddit.com${post.permalink}`
+    : null;
+
+  return {
+    title: nullableString(post.title) ?? 'Reddit post',
+    body: nullableString(post.selftext) ?? '',
+    outboundUrl: post.is_self ? null : nullableString(post.url),
+    author: nullableString(post.author) ? `u/${post.author}` : null,
+    subreddit: nullableString(post.subreddit),
+    postId: nullableString(post.id),
+    permalink,
+    commentsTotal: Number.isInteger(post.num_comments) ? post.num_comments : null,
+    comments
+  };
+}
+
+function renderRedditMarkdown(post) {
+  const lines = [`# ${post.title}`, ''];
+
+  if (post.body) {
+    lines.push(post.body, '');
+  }
+
+  if (post.outboundUrl) {
+    lines.push(`[Linked content](${post.outboundUrl})`, '');
+  }
+
+  if (post.comments.length > 0) {
+    lines.push('## Top comments', '');
+
+    for (const comment of post.comments) {
+      lines.push(`### ${comment.author ?? 'Unknown author'}`, '');
+      lines.push(comment.body, '');
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function renderRedditHtml(post) {
+  const parts = [`<article>`, `<h1>${escapeHtml(post.title)}</h1>`];
+
+  if (post.body) {
+    parts.push(`<div class="reddit-post-body">${escapeHtml(post.body).replaceAll('\n', '<br>')}</div>`);
+  }
+
+  if (post.outboundUrl) {
+    parts.push(`<p><a href="${escapeHtml(post.outboundUrl)}">Linked content</a></p>`);
+  }
+
+  if (post.comments.length > 0) {
+    parts.push('<section class="reddit-comments">', '<h2>Top comments</h2>');
+
+    for (const comment of post.comments) {
+      parts.push(
+        '<article class="reddit-comment">',
+        `<h3>${escapeHtml(comment.author ?? 'Unknown author')}</h3>`,
+        `<div>${escapeHtml(comment.body).replaceAll('\n', '<br>')}</div>`,
+        '</article>'
+      );
+    }
+
+    parts.push('</section>');
+  }
+
+  parts.push('</article>');
+  return parts.join('');
+}
+
+function renderRedditText(post) {
+  const lines = [post.title];
+
+  if (post.body) {
+    lines.push(post.body);
+  }
+
+  if (post.outboundUrl) {
+    lines.push(`Linked content: ${post.outboundUrl}`);
+  }
+
+  if (post.comments.length > 0) {
+    lines.push('Top comments');
+
+    for (const comment of post.comments) {
+      lines.push(comment.author ?? 'Unknown author');
+      lines.push(comment.body);
+    }
+  }
+
+  return normalizeWhitespace(lines.join('\n'));
+}
+
+export function renderRedditContent(post, format = 'markdown') {
+  switch (format) {
+    case 'html':
+      return renderRedditHtml(post);
+    case 'markdown':
+      return renderRedditMarkdown(post);
+    case 'text':
+      return renderRedditText(post);
+    default:
+      throw new Error(`Unsupported format: ${format}`);
+  }
+}
+
+export class RedditParser {
+  async fetchRedditPost(url) {
+    try {
+      const response = await axios.get(normalizeRedditJsonUrl(url), {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; MCPBot/1.0)'
+        }
+      });
+
+      return parseRedditResponse(response.data);
+    } catch (error) {
+      throw new Error(`Failed to fetch or parse Reddit content: ${error.message}`);
+    }
+  }
+
+  async fetchAndParse(url, options = {}) {
+    const post = await this.fetchRedditPost(url);
+    const format = options.format ?? 'markdown';
+    const renderedContent = renderRedditContent(post, format);
+    const { content, truncated } = truncateRenderedContent(renderedContent, options.maxChars);
+
+    return {
+      title: post.title,
+      content,
+      metadata: buildMetadata({
+        format,
+        excerpt: null,
+        byline: post.author,
+        siteName: 'Reddit',
+        truncated,
+        permalink: post.permalink ?? url,
+        provider: {
+          type: 'reddit',
+          subreddit: post.subreddit,
+          postId: post.postId,
+          commentsIncluded: post.comments.length,
+          commentsTotal: post.commentsTotal
+        }
+      })
+    };
+  }
+}
+
+export class WebContentParser {
+  constructor({
+    websiteParser = new WebsiteParser(),
+    redditParser = new RedditParser()
+  } = {}) {
+    this.websiteParser = websiteParser;
+    this.redditParser = redditParser;
+  }
+
+  async fetchAndParse(url, options = {}) {
+    if (isRedditUrl(url)) {
+      return this.redditParser.fetchAndParse(url, options);
+    }
+
+    return this.websiteParser.fetchAndParse(url, options);
   }
 }
 
 // Create MCP server instance
 const server = new Server({
-  name: "server-readability-parser",
+  name: "make-content-parsable",
   version: "1.0.0"
 }, {
   capabilities: { tools: {} }
 });
 
-const parser = new WebsiteParser();
+const parser = new WebContentParser();
 
 // Define available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [{
-    name: "parse",
-    description: "Extracts and transforms webpage content into clean, LLM-optimized Markdown. Returns article title, main content, excerpt, byline and site name. Uses Mozilla's Readability algorithm to remove ads, navigation, footers and non-essential elements while preserving the core content structure.",
+    name: TOOL_NAME,
+    description: "Use this when the user asks you to read, summarize, quote, analyze, or extract readable content from a web URL. For normal web pages it uses Mozilla Readability to remove ads/navigation/page chrome. For public Reddit URLs it uses Reddit JSON and returns the post plus top comments. Prefer this over generic web fetching when the LLM needs clean rendered content rather than raw HTML.",
     inputSchema: {
       type: "object",
       properties: {
         url: {
           type: "string",
-          description: "The website URL to parse"
+          description: "The full URL whose readable content should be extracted."
         },
         format: {
           type: "string",
           enum: ["html", "markdown", "text"],
-          description: "Output format for the parsed article content. Defaults to markdown."
+          description: "Output format for the extracted content. Use markdown for most LLM workflows. Defaults to markdown."
         },
         maxChars: {
           type: "integer",
-          minimum: 0,
-          description: "Optional maximum number of characters to return after rendering."
+          minimum: -1,
+          description: "Optional maximum number of characters to return after rendering. Defaults to -1, which means no limit."
         }
       },
       required: ["url"]
@@ -141,7 +430,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
-  if (name !== "parse") {
+  if (name !== TOOL_NAME) {
     throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
   }
 
@@ -153,8 +442,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     throw new McpError(ErrorCode.InvalidParams, "format must be one of: html, markdown, text");
   }
 
-  if (args.maxChars != null && (!Number.isInteger(args.maxChars) || args.maxChars < 0)) {
-    throw new McpError(ErrorCode.InvalidParams, "maxChars must be a non-negative integer");
+  if (args.maxChars != null && (!Number.isInteger(args.maxChars) || args.maxChars < -1)) {
+    throw new McpError(ErrorCode.InvalidParams, "maxChars must be an integer greater than or equal to -1");
   }
 
   try {
@@ -169,13 +458,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         text: JSON.stringify({
           title: result.title,
           content: result.content,
-          metadata: {
-            format: result.format,
-            excerpt: result.excerpt,
-            byline: result.byline,
-            siteName: result.siteName,
-            truncated: result.truncated
-          }
+          metadata: result.metadata
         }, null, 2)
       }]
     };

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "server-moz-readability",
+  "name": "make-content-parsable",
   "version": "1.0.3",
-  "description": "Fetch just the main content and convert it to markdown. Strips away all the junk, which is cleaner for LLMs and reduces your overall context window.",
+  "description": "Extract clean, parsable content from web URLs, including readable pages and public Reddit posts.",
   "license": "MIT",
   "author": "Max Zimmer (emzimmer.com)",
-  "homepage": "https://github.com/emzimmer/server-moz-readability",
-  "bugs": "https://github.com/emzimmer/server-moz-readability/issues",
+  "homepage": "https://github.com/stefanstr/make-content-parsable",
+  "bugs": "https://github.com/stefanstr/make-content-parsable/issues",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "server-moz-readability": "./dist/index.js"
+    "make-content-parsable": "./dist/index.js"
   },
   "scripts": {
     "start": "node ./dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -1,51 +1,52 @@
-# Mozilla Readability Parser MCP Server
+# Make Content Parsable
 
-An [model context protocol (MCP)](https://github.com/modelcontextprotocol) server that extracts and transforms webpage content into clean, LLM-optimized Markdown. Returns article title, main content, excerpt, byline and site name. Uses [Mozilla's Readability algorithm](https://github.com/mozilla/readability) to remove ads, navigation, footers and non-essential elements while preserving the core content structure. [More about MCP](https://modelcontextprotocol.io/introduction).
-
-<a href="https://glama.ai/mcp/servers/jdcx8fmajm"><img width="380" height="200" src="https://glama.ai/mcp/servers/jdcx8fmajm/badge" alt="Mozilla Readability Parser Server MCP server" /></a>
+An [model context protocol (MCP)](https://github.com/modelcontextprotocol) server that makes web content easier for LLMs to parse. It extracts clean Markdown, HTML, or text from normal web pages with Mozilla Readability, and it natively handles public Reddit URLs by returning the post plus top comments. [More about MCP](https://modelcontextprotocol.io/introduction).
 
 ## Features
-- Removes ads, navigation, footers and other non-essential content
-- Converts clean HTML into well-formatted Markdown (also uses Turndown)
-- Returns article metadata (title, excerpt, byline, site name)
+- Removes ads, navigation, footers and other non-essential content from regular web pages
+- Converts readable content into well-formatted Markdown, HTML, or plain text
+- Extracts public Reddit posts and top comments without OAuth
+- Returns stable metadata including permalink, provider type, excerpt, byline, and site name
 - Handles errors gracefully
 
 ## Why Not Just Fetch?
 Unlike simple fetch requests, this server:
-- Extracts only relevant content using Mozilla's Readability algorithm
-- Eliminates noise like ads, popups, and navigation menus
+- Extracts relevant content using provider-specific parsing
+- Eliminates web page noise like ads, popups, and navigation menus
+- Handles Reddit URLs through Reddit JSON instead of brittle page scraping
 - Reduces token usage by removing unnecessary HTML/CSS
-- Provides consistent Markdown formatting for better LLM processing
+- Provides consistent formatting for better LLM processing
 - Includes useful metadata about the content
 
 ## Installation
 
 ### Install from npm
 ```bash
-npm install server-moz-readability
+npm install make-content-parsable
 ```
 
 ## Tool Reference
 
-### `parse`
-Fetches and transforms webpage content into cleaned article output.
+### `extract_web_content`
+Use this when the user asks the model to read, summarize, quote, analyze, or extract readable content from a web URL. Normal web pages are extracted with Mozilla Readability. Public Reddit URLs are extracted through Reddit JSON and return the post plus top comments.
 
 **Arguments:**
 ```json
 {
   "url": {
     "type": "string",
-    "description": "The website URL to parse",
+    "description": "The full URL whose readable content should be extracted.",
     "required": true
   },
   "format": {
     "type": "string",
     "enum": ["html", "markdown", "text"],
-    "description": "Optional output format. Defaults to markdown."
+    "description": "Optional output format. Use markdown for most LLM workflows. Defaults to markdown."
   },
   "maxChars": {
     "type": "integer",
-    "description": "Optional character limit applied after rendering."
+    "minimum": -1,
+    "description": "Optional character limit applied after rendering. Defaults to -1, which means no limit."
   }
 }
 ```
@@ -57,26 +58,34 @@ Fetches and transforms webpage content into cleaned article output.
   "content": "Rendered article content...",
   "metadata": {
     "format": "markdown",
-    "excerpt": "Brief summary",
-    "byline": "Author information",
-    "siteName": "Source website name",
-    "truncated": false
+    "excerpt": "Brief summary or null",
+    "byline": "Author information or null",
+    "siteName": "Source website name or null",
+    "truncated": false,
+    "permalink": "https://example.com/article",
+    "provider": {
+      "type": "web"
+    }
   }
 }
 ```
+
+For Reddit URLs, `provider.type` is `reddit`, `siteName` is `Reddit`, `excerpt` is `null` unless Reddit provides a natural excerpt, and provider-specific details such as subreddit, post id, and included comment counts may appear under `metadata.provider`.
 
 ## Usage with Claude Desktop
 Add to your `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "readability": {
+    "make-content-parsable": {
       "command": "npx",
-      "args": ["-y", "server-moz-readability"]
+      "args": ["-y", "make-content-parsable"]
     }
   }
 }
 ```
+
+The advertised MCP tool is `extract_web_content`.
 
 ## Dependencies
 - @mozilla/readability - Content extraction

--- a/scripts/test-parse.mjs
+++ b/scripts/test-parse.mjs
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { WebsiteParser, renderArticleContent, truncateRenderedContent } from "../dist/index.js";
+import {
+  RedditParser,
+  TOOL_NAME,
+  WebContentParser,
+  WebsiteParser,
+  isRedditUrl,
+  renderArticleContent,
+  renderRedditContent,
+  truncateRenderedContent
+} from "../dist/index.js";
 
 const sampleArticle = {
   title: "Sample title",
@@ -35,6 +44,16 @@ test("renderArticleContent returns text derived from article html", () => {
 });
 
 test("truncateRenderedContent clips after rendering and reports truncation", () => {
+  assert.deepEqual(truncateRenderedContent("abcdef"), {
+    content: "abcdef",
+    truncated: false
+  });
+
+  assert.deepEqual(truncateRenderedContent("abcdef", -1), {
+    content: "abcdef",
+    truncated: false
+  });
+
   assert.deepEqual(truncateRenderedContent("abcdef", 6), {
     content: "abcdef",
     truncated: false
@@ -44,9 +63,19 @@ test("truncateRenderedContent clips after rendering and reports truncation", () 
     content: "abcd",
     truncated: true
   });
+
+  assert.deepEqual(truncateRenderedContent("abcdef", 0), {
+    content: "",
+    truncated: true
+  });
+
+  assert.throws(
+    () => truncateRenderedContent("abcdef", -2),
+    /maxChars must be an integer greater than or equal to -1/
+  );
 });
 
-test("WebsiteParser fetchAndParse preserves markdown default and supports maxChars", async () => {
+test("WebsiteParser fetchAndParse returns common metadata and supports maxChars", async () => {
   class StubParser extends WebsiteParser {
     async fetchArticle() {
       return {
@@ -67,8 +96,13 @@ test("WebsiteParser fetchAndParse preserves markdown default and supports maxCha
   const parser = new StubParser();
 
   const defaultResult = await parser.fetchAndParse("https://example.com/story");
-  assert.equal(defaultResult.format, "markdown");
-  assert.equal(defaultResult.truncated, false);
+  assert.equal(defaultResult.metadata.format, "markdown");
+  assert.equal(defaultResult.metadata.truncated, false);
+  assert.equal(defaultResult.metadata.excerpt, "Story excerpt");
+  assert.equal(defaultResult.metadata.byline, "Story author");
+  assert.equal(defaultResult.metadata.siteName, "Story site");
+  assert.equal(defaultResult.metadata.permalink, "https://example.com/story");
+  assert.deepEqual(defaultResult.metadata.provider, { type: "web" });
   assert.match(defaultResult.content, /# Story title/);
 
   const htmlResult = await parser.fetchAndParse("https://example.com/story", { format: "html" });
@@ -76,5 +110,114 @@ test("WebsiteParser fetchAndParse preserves markdown default and supports maxCha
 
   const textResult = await parser.fetchAndParse("https://example.com/story", { format: "text", maxChars: 12 });
   assert.equal(textResult.content, "Story title ");
-  assert.equal(textResult.truncated, true);
+  assert.equal(textResult.metadata.truncated, true);
+});
+
+test("only extract_web_content is advertised as the public tool name", () => {
+  assert.equal(TOOL_NAME, "extract_web_content");
+  assert.notEqual(TOOL_NAME, "extract_article_content");
+});
+
+test("isRedditUrl detects supported Reddit hosts", () => {
+  assert.equal(isRedditUrl("https://reddit.com/r/test/comments/abc/title/"), true);
+  assert.equal(isRedditUrl("https://www.reddit.com/r/test/comments/abc/title/"), true);
+  assert.equal(isRedditUrl("https://old.reddit.com/r/test/comments/abc/title/"), true);
+  assert.equal(isRedditUrl("https://redd.it/abc"), true);
+  assert.equal(isRedditUrl("https://example.com/r/test/comments/abc/title/"), false);
+  assert.equal(isRedditUrl("not a url"), false);
+});
+
+test("WebContentParser routes Reddit URLs to RedditParser and other URLs to WebsiteParser", async () => {
+  const calls = [];
+  const parser = new WebContentParser({
+    websiteParser: {
+      async fetchAndParse(url) {
+        calls.push(["web", url]);
+        return { title: "web", content: "web", metadata: { provider: { type: "web" } } };
+      }
+    },
+    redditParser: {
+      async fetchAndParse(url) {
+        calls.push(["reddit", url]);
+        return { title: "reddit", content: "reddit", metadata: { provider: { type: "reddit" } } };
+      }
+    }
+  });
+
+  assert.equal((await parser.fetchAndParse("https://example.com/story")).metadata.provider.type, "web");
+  assert.equal((await parser.fetchAndParse("https://www.reddit.com/r/test/comments/abc/title/")).metadata.provider.type, "reddit");
+  assert.deepEqual(calls, [
+    ["web", "https://example.com/story"],
+    ["reddit", "https://www.reddit.com/r/test/comments/abc/title/"]
+  ]);
+});
+
+test("renderRedditContent supports markdown, html, and text", () => {
+  const post = {
+    title: "Reddit title",
+    body: "Post body",
+    outboundUrl: "https://example.com/linked",
+    comments: [{
+      author: "u/commenter",
+      body: "Comment body"
+    }]
+  };
+
+  const markdown = renderRedditContent(post);
+  assert.match(markdown, /# Reddit title/);
+  assert.match(markdown, /\[Linked content\]\(https:\/\/example\.com\/linked\)/);
+  assert.match(markdown, /## Top comments/);
+  assert.match(markdown, /Comment body/);
+
+  const html = renderRedditContent(post, "html");
+  assert.match(html, /<article>/);
+  assert.match(html, /<h1>Reddit title<\/h1>/);
+  assert.match(html, /<section class="reddit-comments">/);
+
+  const text = renderRedditContent(post, "text");
+  assert.equal(text, "Reddit title Post body Linked content: https://example.com/linked Top comments u/commenter Comment body");
+});
+
+test("RedditParser fetchAndParse returns common metadata and respects maxChars", async () => {
+  class StubRedditParser extends RedditParser {
+    async fetchRedditPost() {
+      return {
+        title: "Reddit title",
+        body: "Post body alpha beta.",
+        outboundUrl: null,
+        author: "u/poster",
+        subreddit: "test",
+        postId: "abc123",
+        permalink: "https://www.reddit.com/r/test/comments/abc123/title/",
+        commentsTotal: 2,
+        comments: [
+          { author: "u/one", body: "First comment." },
+          { author: "u/two", body: "Second comment." }
+        ]
+      };
+    }
+  }
+
+  const parser = new StubRedditParser();
+  const result = await parser.fetchAndParse("https://www.reddit.com/r/test/comments/abc123/title/", {
+    maxChars: 20
+  });
+
+  assert.equal(result.title, "Reddit title");
+  assert.equal(result.content, "# Reddit title\n\nPost");
+  assert.deepEqual(result.metadata, {
+    format: "markdown",
+    excerpt: null,
+    byline: "u/poster",
+    siteName: "Reddit",
+    truncated: true,
+    permalink: "https://www.reddit.com/r/test/comments/abc123/title/",
+    provider: {
+      type: "reddit",
+      subreddit: "test",
+      postId: "abc123",
+      commentsIncluded: 2,
+      commentsTotal: 2
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Rename the package and MCP server to Make Content Parsable
- Replace the public tool with a single `extract_web_content` tool
- Add native Reddit URL routing through public Reddit JSON, returning posts plus top comments
- Standardize metadata across web and Reddit providers, including `provider.type` and `permalink`
- Support `maxChars: -1` as the default no-limit mode

## Validation

- `npm test`