### PR TITLE
[codex] Add fixture-based regression tests

### DIFF
--- a/scripts/fixtures/blocked-local-urls.json
+++ b/scripts/fixtures/blocked-local-urls.json
@@ -1,0 +1,18 @@
+[
+  {
+    "url": "file:///etc/passwd",
+    "message": "URL must use http or https"
+  },
+  {
+    "url": "http://localhost:3000/admin",
+    "message": "Private or local hosts are blocked by policy: localhost"
+  },
+  {
+    "url": "http://127.0.0.1:3000/admin",
+    "message": "Private or local hosts are blocked by policy: 127.0.0.1"
+  },
+  {
+    "url": "http://[::1]/private",
+    "message": "Private or local hosts are blocked by policy: ::1"
+  }
+]

--- a/scripts/fixtures/boilerplate-heavy-intro.html
+++ b/scripts/fixtures/boilerplate-heavy-intro.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Sustainable Maps for Busy Cities</title>
+    <meta name="author" content="Jon Bell">
+    <meta property="og:site_name" content="Civic Notes">
+  </head>
+  <body>
+    <div class="cookie-banner" hidden>
+      Accept cookies to unlock personalized recommendations, partner offers, and sponsored stories.
+    </div>
+    <header>
+      <h2>Civic Notes</h2>
+      <nav>
+        <a href="/subscribe">Subscribe</a>
+        <a href="/events">Events</a>
+        <a href="/jobs">Jobs</a>
+        <a href="/shop">Shop</a>
+      </nav>
+    </header>
+    <aside>
+      <h2>Most Popular</h2>
+      <ol>
+        <li>Ten gadgets for commuters</li>
+        <li>Sponsored: smarter luggage</li>
+        <li>Newsletter signup</li>
+      </ol>
+    </aside>
+    <main>
+      <article>
+        <h1>Sustainable Maps for Busy Cities</h1>
+        <p>City planners are updating street maps so buses, bikes, and delivery zones can share limited curb space.</p>
+        <p>The best pilots publish their assumptions early, then let residents challenge them before crews repaint intersections.</p>
+        <p>That slow feedback loop prevents a digital model from becoming a quiet source of public frustration.</p>
+      </article>
+    </main>
+    <footer>
+      Subscribe to our newsletter and follow us on every platform.
+    </footer>
+  </body>
+</html>

--- a/scripts/fixtures/clean-article.html
+++ b/scripts/fixtures/clean-article.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Deep Work in Small Windows - Example Daily</title>
+    <meta name="author" content="Mara Ionescu">
+    <meta name="description" content="A practical look at protecting attention during a crowded workday.">
+    <meta property="og:site_name" content="Example Daily">
+  </head>
+  <body>
+    <header>
+      <a href="/">Example Daily</a>
+      <nav>
+        <a href="/markets">Markets</a>
+        <a href="/style">Style</a>
+      </nav>
+    </header>
+    <main>
+      <article>
+        <h1>Deep Work in Small Windows</h1>
+        <p class="dek">A practical look at protecting attention during a crowded workday.</p>
+        <p>Most calendars are not built for concentration, but a short protected window can still produce careful work.</p>
+        <p>The key is to name the one decision that matters and leave routine sorting for later.</p>
+      </article>
+    </main>
+    <footer>Copyright 2026 Example Daily</footer>
+  </body>
+</html>

--- a/scripts/fixtures/list-heavy-page.html
+++ b/scripts/fixtures/list-heavy-page.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Checklist for Launching a Public Dataset</title>
+    <meta property="og:site_name" content="Open Data Handbook">
+  </head>
+  <body>
+    <main>
+      <article>
+        <h1>Checklist for Launching a Public Dataset</h1>
+        <p>A useful dataset release explains what changed, what is missing, and how maintainers will answer questions.</p>
+        <h2>Before publication</h2>
+        <ul>
+          <li>Confirm every column has a plain-language definition.</li>
+          <li>Publish the license next to the download link.</li>
+          <li>Include a stable contact path for corrections.</li>
+        </ul>
+        <h2>After publication</h2>
+        <ol>
+          <li>Record the first external question.</li>
+          <li>Add a changelog entry for every schema update.</li>
+          <li>Archive superseded files without breaking old links.</li>
+        </ol>
+      </article>
+    </main>
+  </body>
+</html>

--- a/scripts/fixtures/non-html-response.json
+++ b/scripts/fixtures/non-html-response.json
@@ -1,0 +1,9 @@
+{
+  "status": 200,
+  "headers": {
+    "content-type": "application/json"
+  },
+  "data": {
+    "title": "Not an HTML page"
+  }
+}

--- a/scripts/fixtures/redirect-chain.json
+++ b/scripts/fixtures/redirect-chain.json
@@ -1,0 +1,18 @@
+[
+  {
+    "url": "https://example.com/start",
+    "status": 302,
+    "headers": {
+      "location": "/articles/final"
+    },
+    "data": ""
+  },
+  {
+    "url": "https://example.com/articles/final",
+    "status": 200,
+    "headers": {
+      "content-type": "text/html; charset=utf-8"
+    },
+    "dataFixture": "clean-article.html"
+  }
+]

--- a/scripts/test-parse.mjs
+++ b/scripts/test-parse.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -29,6 +29,18 @@ const sampleArticle = {
   byline: "Sample author",
   siteName: "Sample site"
 };
+
+function loadFixture(name) {
+  return readFileSync(new URL(`./fixtures/${name}`, import.meta.url), "utf8");
+}
+
+function loadJsonFixture(name) {
+  return JSON.parse(loadFixture(name));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function withUrlPolicyEnv(env, callback) {
   const keys = ["ALLOW_PRIVATE_HOSTS", "ALLOWED_HOSTS", "BLOCKED_HOSTS"];
@@ -60,6 +72,75 @@ function withUrlPolicyEnv(env, callback) {
     }
   }
 }
+
+test("WebsiteParser extracts representative HTML fixtures across formats and truncation", async () => {
+  const cases = [
+    {
+      name: "clean-article.html",
+      url: "https://example.com/deep-work",
+      title: "Deep Work in Small Windows",
+      expectedMarkdown: [
+        "Most calendars are not built for concentration",
+        "The key is to name the one decision"
+      ],
+      absentMarkdown: ["Markets", "Copyright 2026"]
+    },
+    {
+      name: "boilerplate-heavy-intro.html",
+      url: "https://example.com/cities/maps",
+      title: "Sustainable Maps for Busy Cities",
+      expectedMarkdown: [
+        "City planners are updating street maps",
+        "quiet source of public frustration"
+      ],
+      absentMarkdown: ["Accept cookies", "Sponsored: smarter luggage", "Subscribe to our newsletter"]
+    },
+    {
+      name: "list-heavy-page.html",
+      url: "https://example.com/open-data/checklist",
+      title: "Checklist for Launching a Public Dataset",
+      expectedMarkdown: [
+        "## Before publication",
+        "*   Confirm every column has a plain-language definition.",
+        "1.  Record the first external question."
+      ],
+      absentMarkdown: []
+    }
+  ];
+
+  for (const fixtureCase of cases) {
+    const parser = new WebsiteParser({
+      httpClient: async () => ({
+        data: loadFixture(fixtureCase.name),
+        finalUrl: fixtureCase.url,
+        headers: { "content-type": "text/html" }
+      })
+    });
+
+    const markdownResult = await parser.fetchAndParse(fixtureCase.url);
+    assert.equal(markdownResult.title, fixtureCase.title);
+    assert.equal(markdownResult.metadata.format, "markdown");
+    assert.equal(markdownResult.metadata.permalink, fixtureCase.url);
+    assert.deepEqual(markdownResult.metadata.provider, { type: "web" });
+
+    for (const expected of fixtureCase.expectedMarkdown) {
+      assert.match(markdownResult.content, new RegExp(escapeRegExp(expected)));
+    }
+
+    for (const absent of fixtureCase.absentMarkdown) {
+      assert.doesNotMatch(markdownResult.content, new RegExp(escapeRegExp(absent)));
+    }
+
+    const htmlResult = await parser.fetchAndParse(fixtureCase.url, { format: "html" });
+    assert.match(htmlResult.content, /<article>|<p>/);
+    assert.equal(htmlResult.metadata.format, "html");
+
+    const textResult = await parser.fetchAndParse(fixtureCase.url, { format: "text", maxChars: 80 });
+    assert.equal(textResult.content.length, 80);
+    assert.equal(textResult.metadata.format, "text");
+    assert.equal(textResult.metadata.truncated, true);
+  }
+});
 
 test("renderArticleContent returns markdown by default", () => {
   const rendered = renderArticleContent(sampleArticle);
@@ -226,6 +307,20 @@ test("WebsiteParser validateUrl enforces default URL hygiene", () => {
   });
 });
 
+test("WebsiteParser rejects blocked and local URL fixtures", () => {
+  withUrlPolicyEnv({}, () => {
+    const parser = new WebsiteParser();
+    const blockedUrls = loadJsonFixture("blocked-local-urls.json");
+
+    for (const fixtureCase of blockedUrls) {
+      assert.throws(
+        () => parser.validateUrl(fixtureCase.url),
+        new RegExp(escapeRegExp(fixtureCase.message))
+      );
+    }
+  });
+});
+
 test("WebsiteParser validateUrl supports private-host escape hatch", () => {
   withUrlPolicyEnv({ ALLOW_PRIVATE_HOSTS: "true" }, () => {
     const parser = new WebsiteParser();
@@ -304,15 +399,42 @@ test("fetchWithPolicy blocks redirects to private hosts", async () => {
   assert.deepEqual(requestedUrls, ["https://example.com/start"]);
 });
 
+test("fetchWithPolicy follows fixture redirect chain and returns the final HTML response", async () => {
+  const responses = loadJsonFixture("redirect-chain.json");
+  const requestedUrls = [];
+
+  const response = await fetchWithPolicy("https://example.com/start", {
+    allowedContentTypes: new Set(["text/html"]),
+    requester: async (url) => {
+      requestedUrls.push(url);
+      const fixtureResponse = responses.find(item => item.url === url);
+      assert.ok(fixtureResponse, `Missing redirect fixture response for ${url}`);
+
+      return {
+        status: fixtureResponse.status,
+        headers: fixtureResponse.headers,
+        data: fixtureResponse.dataFixture
+          ? loadFixture(fixtureResponse.dataFixture)
+          : fixtureResponse.data
+      };
+    }
+  });
+
+  assert.deepEqual(requestedUrls, [
+    "https://example.com/start",
+    "https://example.com/articles/final"
+  ]);
+  assert.equal(response.finalUrl, "https://example.com/articles/final");
+  assert.match(response.data, /Deep Work in Small Windows/);
+});
+
 test("fetchWithPolicy rejects unsupported content types before parsing", async () => {
+  const fixtureResponse = loadJsonFixture("non-html-response.json");
+
   await assert.rejects(
     () => fetchWithPolicy("https://example.com/file.pdf", {
       allowedContentTypes: new Set(["text/html"]),
-      requester: async () => ({
-        status: 200,
-        headers: { "content-type": "application/pdf" },
-        data: "%PDF"
-      })
+      requester: async () => fixtureResponse
     }),
     /Unsupported response content type/
   );


### PR DESCRIPTION
## Summary
- Add reusable fixtures for clean articles, boilerplate-heavy intros, list-heavy pages, redirect chains, non-HTML responses, and blocked/local URLs.
- Extend the parser test suite to assert fixture extraction across markdown, HTML, text, truncation metadata, redirect policy, content-type rejection, and URL safety behavior.

## Validation
- npm test

Addresses #8.