### PR TITLE
[codex] Improve fetch error reporting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32,6 +32,7 @@ const MAX_RESPONSE_BYTES_LABEL = '5 MiB';
 const MAX_REDIRECTS = 5;
 const HTML_CONTENT_TYPES = new Set(['text/html', 'application/xhtml+xml']);
 const JSON_CONTENT_TYPES = new Set(['application/json', 'text/json']);
+const DEFAULT_CONTENT_TYPE_ERROR_MESSAGE = 'Unsupported response content type';
 const LOCALHOST_NAMES = new Set(['localhost']);
 const PRIVATE_ADDRESS_BLOCK_LIST = createPrivateAddressBlockList();
 
@@ -189,7 +190,7 @@ function validateHttpUrl(url) {
   try {
     parsed = new URL(url);
   } catch {
-    throw new PublicError('URL must be a valid absolute URL');
+    throw new PublicError('Invalid URL');
   }
 
   const hostname = normalizeHostname(parsed.hostname);
@@ -197,7 +198,7 @@ function validateHttpUrl(url) {
   const allowedHosts = parseHostList(process.env.ALLOWED_HOSTS);
 
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new PublicError('URL must use http or https');
+    throw new PublicError('Invalid URL: URL must use http or https');
   }
 
   if (blockedHosts.has(hostname)) {
@@ -250,11 +251,11 @@ function normalizeContentType(value) {
   return (value ?? '').split(';', 1)[0].trim().toLowerCase();
 }
 
-function assertAllowedContentType(response, allowedContentTypes) {
+function assertAllowedContentType(response, allowedContentTypes, message = DEFAULT_CONTENT_TYPE_ERROR_MESSAGE) {
   const contentType = normalizeContentType(response.headers?.['content-type']);
 
   if (!contentType || !allowedContentTypes.has(contentType)) {
-    throw new PublicError('Unsupported response content type');
+    throw new PublicError(message);
   }
 }
 
@@ -269,6 +270,19 @@ function isAxiosResponseSizeLimitError(error) {
     && /maxContentLength size of \d+ exceeded/.test(message);
 }
 
+function isAxiosTimeoutError(error) {
+  const message = typeof error?.message === 'string' ? error.message : '';
+
+  return (axios.isAxiosError(error) || error?.name === 'AxiosError')
+    && (error?.code === 'ECONNABORTED'
+      || error?.code === 'ETIMEDOUT'
+      || /timeout of \d+ms exceeded/i.test(message));
+}
+
+function isAxiosFetchError(error) {
+  return axios.isAxiosError(error) || error?.name === 'AxiosError';
+}
+
 function isRedirectStatus(status) {
   return status >= 300 && status < 400;
 }
@@ -278,7 +292,8 @@ export async function fetchWithPolicy(url, {
   responseType = 'text',
   requester = defaultHttpRequester,
   validateUrl = validateHttpUrl,
-  maxRedirects = MAX_REDIRECTS
+  maxRedirects = MAX_REDIRECTS,
+  contentTypeErrorMessage = DEFAULT_CONTENT_TYPE_ERROR_MESSAGE
 } = {}) {
   let currentUrl = validateUrl(url);
 
@@ -303,6 +318,14 @@ export async function fetchWithPolicy(url, {
         throw new PublicError(`Response exceeded maximum fetch size of ${MAX_RESPONSE_BYTES_LABEL}`);
       }
 
+      if (isAxiosTimeoutError(error)) {
+        throw new PublicError('Request timed out');
+      }
+
+      if (isAxiosFetchError(error)) {
+        throw new PublicError('Failed to fetch web content');
+      }
+
       throw error;
     }
 
@@ -321,7 +344,7 @@ export async function fetchWithPolicy(url, {
     }
 
     if (allowedContentTypes) {
-      assertAllowedContentType(response, allowedContentTypes);
+      assertAllowedContentType(response, allowedContentTypes, contentTypeErrorMessage);
     }
 
     return {
@@ -379,6 +402,7 @@ export class WebsiteParser {
   async fetchHtml(url) {
     const response = await this.httpClient(url, {
       allowedContentTypes: HTML_CONTENT_TYPES,
+      contentTypeErrorMessage: 'Non-HTML response',
       responseType: 'text'
     });
 
@@ -403,16 +427,27 @@ export class WebsiteParser {
   }
 
   async fetchArticle(url) {
+    const validatedUrl = this.validateUrl(url);
+    let html;
+
     try {
-      const validatedUrl = this.validateUrl(url);
-      const html = await this.fetchHtml(validatedUrl);
-      return this.extractArticle(html, validatedUrl);
+      html = await this.fetchHtml(validatedUrl);
     } catch (error) {
       if (error instanceof PublicError) {
         throw error;
       }
 
       throw new PublicError('Failed to fetch web content');
+    }
+
+    try {
+      return this.extractArticle(html, validatedUrl);
+    } catch (error) {
+      if (error instanceof PublicError) {
+        throw error;
+      }
+
+      throw new PublicError('Failed to parse web content');
     }
   }
 

--- a/scripts/test-parse.mjs
+++ b/scripts/test-parse.mjs
@@ -444,6 +444,47 @@ test("fetchWithPolicy reports oversized responses as public errors", async () =>
   );
 });
 
+test("fetchWithPolicy normalizes timeout failures", async () => {
+  const axiosError = Object.assign(new Error("timeout of 10000ms exceeded"), {
+    name: "AxiosError",
+    code: "ECONNABORTED"
+  });
+
+  await assert.rejects(
+    () => fetchWithPolicy("https://example.com/slow", {
+      requester: async () => {
+        throw axiosError;
+      }
+    }),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Request timed out");
+      return true;
+    }
+  );
+});
+
+test("fetchWithPolicy normalizes low-level fetch failures", async () => {
+  const axiosError = Object.assign(new Error("getaddrinfo ENOTFOUND example.invalid"), {
+    name: "AxiosError",
+    code: "ENOTFOUND"
+  });
+
+  await assert.rejects(
+    () => fetchWithPolicy("https://example.invalid/story", {
+      requester: async () => {
+        throw axiosError;
+      }
+    }),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Failed to fetch web content");
+      assert.doesNotMatch(error.message, /ENOTFOUND|example\.invalid/);
+      return true;
+    }
+  );
+});
+
 test("fetchWithPolicy blocks redirects to private hosts", async () => {
   const requestedUrls = [];
 
@@ -463,6 +504,34 @@ test("fetchWithPolicy blocks redirects to private hosts", async () => {
   );
 
   assert.deepEqual(requestedUrls, ["https://example.com/start"]);
+});
+
+test("fetchWithPolicy reports redirect loops with a stable message", async () => {
+  const requestedUrls = [];
+
+  await assert.rejects(
+    () => fetchWithPolicy("https://example.com/start", {
+      maxRedirects: 1,
+      requester: async (url) => {
+        requestedUrls.push(url);
+        return {
+          status: 302,
+          headers: { location: "/next" },
+          data: ""
+        };
+      }
+    }),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Too many redirects");
+      return true;
+    }
+  );
+
+  assert.deepEqual(requestedUrls, [
+    "https://example.com/start",
+    "https://example.com/next"
+  ]);
 });
 
 test("fetchWithPolicy follows fixture redirect chain and returns the final HTML response", async () => {
@@ -503,6 +572,55 @@ test("fetchWithPolicy rejects unsupported content types before parsing", async (
       requester: async () => fixtureResponse
     }),
     /Unsupported response content type/
+  );
+});
+
+test("WebsiteParser reports invalid and non-HTML URLs with stable messages", async () => {
+  const parser = new WebsiteParser({
+    httpClient: (url, options) => fetchWithPolicy(url, {
+      ...options,
+      requester: async () => loadJsonFixture("non-html-response.json")
+    })
+  });
+
+  await assert.rejects(
+    () => parser.fetchArticle("not a url"),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Invalid URL");
+      return true;
+    }
+  );
+
+  await assert.rejects(
+    () => parser.fetchArticle("https://example.com/file.pdf"),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Non-HTML response");
+      return true;
+    }
+  );
+});
+
+test("WebsiteParser reports parser failures separately from fetch failures", async () => {
+  class ThrowingParser extends WebsiteParser {
+    async fetchHtml() {
+      return "<html><body><article>Story body</article></body></html>";
+    }
+
+    extractArticle() {
+      throw new Error("readability crashed");
+    }
+  }
+
+  await assert.rejects(
+    () => new ThrowingParser().fetchArticle("https://example.com/story"),
+    error => {
+      assert.ok(error instanceof PublicError);
+      assert.equal(error.message, "Failed to parse web content");
+      assert.doesNotMatch(error.message, /readability crashed/);
+      return true;
+    }
   );
 });
 


### PR DESCRIPTION
## Summary

- Normalize fetch failures into stable public error messages for invalid URLs, timeouts, redirect loops, non-HTML responses, generic fetch failures, and parser failures.
- Keep response content-type validation configurable so website fetches can report non-HTML responses clearly.
- Add regression tests covering the issue #3 acceptance cases.

## Validation

- `npm test`